### PR TITLE
Feat/tag form

### DIFF
--- a/api/product/src/resolvers/tag.resolver.ts
+++ b/api/product/src/resolvers/tag.resolver.ts
@@ -1,9 +1,20 @@
-import { Resolver, Mutation, Arg } from 'type-graphql';
+import { Resolver, Mutation, Arg, Query } from 'type-graphql';
 import { Tag } from '../entity/tag.entities';
 import { CreateTagInput } from '../types/tag.types';
 
 @Resolver(Tag)
 export default class TagResolver {
+  @Query(() => [Tag])
+  async getAllTags(): Promise<Tag[]> {
+    try {
+      return await Tag.find();
+    } catch (error) {
+      throw new Error(
+        `Erreur lors de la récupération des tags: ${error.message}`
+      );
+    }
+  }
+
   @Mutation(() => Tag)
   async createTag(@Arg('input') input: CreateTagInput): Promise<Tag> {
     try {

--- a/client/src/components/TagForm.tsx
+++ b/client/src/components/TagForm.tsx
@@ -35,6 +35,8 @@ const TagForm = () => {
           Tags
         </Typography>
         <Box
+          component="form"
+          onSubmit={handleSubmit}
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -55,6 +57,7 @@ const TagForm = () => {
           />
           <Button
             variant="contained"
+            type="submit"
             onClick={handleSubmit}
             sx={{
               padding: '4px 10px',

--- a/client/src/components/TagForm.tsx
+++ b/client/src/components/TagForm.tsx
@@ -58,7 +58,6 @@ const TagForm = () => {
           <Button
             variant="contained"
             type="submit"
-            onClick={handleSubmit}
             sx={{
               padding: '4px 10px',
               borderRadius: '5px',

--- a/client/src/components/TagForm.tsx
+++ b/client/src/components/TagForm.tsx
@@ -1,0 +1,73 @@
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import { useState } from 'react';
+import { useCreateTagMutation } from '../generated/graphql-types';
+
+const TagForm = () => {
+  const [newTagName, setNewTagName] = useState('');
+  const [createTag] = useCreateTagMutation();
+
+  const handleSubmit = async () => {
+    try {
+      if (newTagName.trim()) {
+        const response = await createTag({
+          variables: {
+            input: { name: newTagName.trim() }
+          }
+        });
+        if (response.data?.createTag) {
+          setNewTagName('');
+        }
+      }
+    } catch (err) {
+      console.error('Error:', err);
+    }
+  };
+
+  return (
+    <Card sx={{ maxWidth: 900, margin: 1, boxShadow: 4 }}>
+      <CardContent>
+        <Typography variant="h6" sx={{ marginBottom: 2 }}>
+          Tags
+        </Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            marginBottom: 2
+          }}
+        >
+          <Typography sx={{ minWidth: 'fit-content' }}>
+            Ajouter un tag :
+          </Typography>
+          <TextField
+            sx={{ maxWidth: '300px', marginLeft: '25px' }}
+            placeholder="Nom"
+            variant="outlined"
+            size="small"
+            value={newTagName}
+            onChange={(e) => setNewTagName(e.target.value)}
+          />
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            sx={{
+              padding: '4px 10px',
+              borderRadius: '5px',
+              backgroundColor: 'green'
+            }}
+          >
+            Ajouter +
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TagForm;

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -52,6 +52,10 @@ export type CreateCategoryInput = {
   name: Scalars['String']['input'];
 };
 
+export type CreateTagInput = {
+  name: Scalars['String']['input'];
+};
+
 export type Image = {
   __typename?: 'Image';
   id: Scalars['Float']['output'];
@@ -70,6 +74,7 @@ export type Mutation = {
   createCategory: Category;
   createNewCharacteristic: Characteristic;
   createNewProduct: Product;
+  createTag: Tag;
   deleteCategory: Scalars['Boolean']['output'];
   restoreCategory: Scalars['Boolean']['output'];
   updateCategory: Category;
@@ -90,6 +95,10 @@ export type MutationCreateNewCharacteristicArgs = {
 
 export type MutationCreateNewProductArgs = {
   data: ProductInput;
+};
+
+export type MutationCreateTagArgs = {
+  input: CreateTagInput;
 };
 
 export type MutationDeleteCategoryArgs = {
@@ -141,6 +150,7 @@ export type Query = {
   getAllCharacteristic: Array<Characteristic>;
   getAllImages: Array<Image>;
   getAllProducts: Array<Product>;
+  getAllTags: Array<Tag>;
   getProductById?: Maybe<Product>;
 };
 
@@ -150,6 +160,12 @@ export type QueryGetAllCategoriesArgs = {
 
 export type QueryGetProductByIdArgs = {
   id: Scalars['Int']['input'];
+};
+
+export type Tag = {
+  __typename?: 'Tag';
+  id: Scalars['Float']['output'];
+  name: Scalars['String']['output'];
 };
 
 export type UpdateCategoryInput = {
@@ -232,6 +248,15 @@ export type DeleteCategoryMutationVariables = Exact<{
 export type DeleteCategoryMutation = {
   __typename?: 'Mutation';
   deleteCategory: boolean;
+};
+
+export type CreateTagMutationVariables = Exact<{
+  input: CreateTagInput;
+}>;
+
+export type CreateTagMutation = {
+  __typename?: 'Mutation';
+  createTag: { __typename?: 'Tag'; id: number; name: string };
 };
 
 export type GetAllProductsQueryVariables = Exact<{ [key: string]: never }>;
@@ -673,6 +698,56 @@ export type DeleteCategoryMutationResult =
 export type DeleteCategoryMutationOptions = Apollo.BaseMutationOptions<
   DeleteCategoryMutation,
   DeleteCategoryMutationVariables
+>;
+export const CreateTagDocument = gql`
+  mutation CreateTag($input: CreateTagInput!) {
+    createTag(input: $input) {
+      id
+      name
+    }
+  }
+`;
+export type CreateTagMutationFn = Apollo.MutationFunction<
+  CreateTagMutation,
+  CreateTagMutationVariables
+>;
+
+/**
+ * __useCreateTagMutation__
+ *
+ * To run a mutation, you first call `useCreateTagMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateTagMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createTagMutation, { data, loading, error }] = useCreateTagMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateTagMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateTagMutation,
+    CreateTagMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<CreateTagMutation, CreateTagMutationVariables>(
+    CreateTagDocument,
+    options
+  );
+}
+export type CreateTagMutationHookResult = ReturnType<
+  typeof useCreateTagMutation
+>;
+export type CreateTagMutationResult = Apollo.MutationResult<CreateTagMutation>;
+export type CreateTagMutationOptions = Apollo.BaseMutationOptions<
+  CreateTagMutation,
+  CreateTagMutationVariables
 >;
 export const GetAllProductsDocument = gql`
   query GetAllProducts {

--- a/client/src/pages/ManagementProduct.tsx
+++ b/client/src/pages/ManagementProduct.tsx
@@ -1,11 +1,13 @@
 import CharacteristicForm from '../components/CharacteristicForm';
 import CategoryForm from '../components/CategoryForm';
+import TagForm from '../components/TagForm';
 
 export default function ManagementProduct() {
   return (
     <>
       <CategoryForm />
       <CharacteristicForm />
+      <TagForm />
     </>
   );
 }

--- a/client/src/schema/mutations.ts
+++ b/client/src/schema/mutations.ts
@@ -64,3 +64,12 @@ export const DELETE_CATEGORY = gql`
     deleteCategory(id: $id)
   }
 `;
+
+export const CREATE_TAG = gql`
+  mutation CreateTag($input: CreateTagInput!) {
+    createTag(input: $input) {
+      id
+      name
+    }
+  }
+`;


### PR DESCRIPTION
## Description
Ajout d'un composant permettant la création de tags via un formulaire simple avec validation.

## Changements apportés
- Ajout du schéma GraphQL pour la mutation de création de tag
- Génération des types TypeScript via codegen
- Création du composant TagForm avec :
  - Champ de saisie pour le nom du tag
  - Bouton d'ajout
