### PR TITLE
add tag management to products

### DIFF
--- a/api/product/src/entity/product.entities.ts
+++ b/api/product/src/entity/product.entities.ts
@@ -14,6 +14,7 @@ import { Image } from './image.entities';
 import { Category } from './category.entities';
 import { Brand } from './brand.entities';
 import { GraphQLDateTime } from 'graphql-scalars';
+import { Tag } from './tag.entities';
 
 @ObjectType()
 @Entity('products')
@@ -62,6 +63,11 @@ export class Product extends BaseEntity {
   @ManyToMany(() => Category)
   @JoinTable()
   categories?: Category[];
+
+  @Field(() => [Tag], { nullable: true })
+  @ManyToMany(() => Tag)
+  @JoinTable()
+  tags?: Tag[];
 
   @Field(() => Brand, { nullable: true })
   @ManyToOne(() => Brand, (brand) => brand.id)

--- a/api/product/src/resolvers/product.resolvers.ts
+++ b/api/product/src/resolvers/product.resolvers.ts
@@ -4,6 +4,7 @@ import { Resolver, Query, Mutation, Arg, Int } from 'type-graphql';
 import { Category } from '../entity/category.entities';
 import { ILike, In } from 'typeorm';
 import { Brand } from '../entity/brand.entities';
+import { Tag } from '../entity/tag.entities';
 
 @Resolver(Product)
 export default class ProductResolver {
@@ -18,7 +19,8 @@ export default class ProductResolver {
       relations: {
         categories: true,
         brand: true,
-        images: true
+        images: true,
+        tags: true
       },
       withDeleted: includeDeleted
     };
@@ -62,6 +64,13 @@ export default class ProductResolver {
       product.categories = categories;
     }
 
+    if (newProduct.tagIds) {
+      const tags = await Tag.findBy({
+        id: In(newProduct.tagIds)
+      });
+      product.tags = tags;
+    }
+
     return await product.save();
   }
 
@@ -73,7 +82,7 @@ export default class ProductResolver {
   ): Promise<Product | null> {
     return await Product.findOne({
       where: { id },
-      relations: ['categories', 'brand', 'images'],
+      relations: ['categories', 'brand', 'images', 'tags'],
       withDeleted: includeDeleted
     });
   }
@@ -86,7 +95,7 @@ export default class ProductResolver {
 
     const product = await Product.findOne({
       where: { id },
-      relations: ['categories', 'brand', 'images']
+      relations: ['categories', 'brand', 'images', 'tags']
     });
 
     if (!product) {
@@ -113,6 +122,13 @@ export default class ProductResolver {
         id: In(newDataProduct.categoryIds)
       });
       product.categories = categories;
+    }
+
+    if (newDataProduct.tagIds) {
+      const tags = await Tag.findBy({
+        id: In(newDataProduct.tagIds)
+      });
+      product.tags = tags;
     }
 
     // if (newDataProduct.imageIds && newDataProduct.imageIds.length > 0) {
@@ -152,7 +168,8 @@ export default class ProductResolver {
         withDeleted: true,
         relations: {
           brand: true,
-          categories: true
+          categories: true,
+          tags: true
         }
       });
 

--- a/api/product/src/types/product.types.ts
+++ b/api/product/src/types/product.types.ts
@@ -20,6 +20,9 @@ export class ProductInput {
   @Field(() => [Int], { nullable: true })
   categoryIds?: number[];
 
+  @Field(() => [Int], { nullable: true })
+  tagIds?: number[];
+
   @Field(() => Boolean)
   isPublished: boolean;
 
@@ -52,6 +55,9 @@ export class ProductUpdateInput {
 
   @Field(() => [Int], { nullable: true })
   categoryIds?: number[];
+
+  @Field(() => [Int], { nullable: true })
+  tagIds?: number[];
 
   @Field(() => Number, { nullable: true })
   brand: number;

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -210,6 +210,7 @@ export type Product = {
   price?: Maybe<Scalars['Float']['output']>;
   reference: Scalars['String']['output'];
   shortDescription?: Maybe<Scalars['String']['output']>;
+  tags?: Maybe<Array<Tag>>;
 };
 
 export type ProductInput = {
@@ -221,6 +222,7 @@ export type ProductInput = {
   price: Scalars['Float']['input'];
   reference: Scalars['String']['input'];
   shortDescription: Scalars['String']['input'];
+  tagIds?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type ProductUpdateInput = {
@@ -233,6 +235,7 @@ export type ProductUpdateInput = {
   price: Scalars['Float']['input'];
   reference: Scalars['String']['input'];
   shortDescription: Scalars['String']['input'];
+  tagIds?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 export type Query = {
@@ -402,6 +405,7 @@ export type UpdateProductMutation = {
       id: number;
       name: string;
     }> | null;
+    tags?: Array<{ __typename?: 'Tag'; id: number; name: string }> | null;
   };
 };
 
@@ -583,6 +587,7 @@ export type GetProductByIdQuery = {
       id: number;
       name: string;
     }> | null;
+    tags?: Array<{ __typename?: 'Tag'; id: number; name: string }> | null;
     brand?: {
       __typename?: 'Brand';
       id: number;
@@ -917,6 +922,10 @@ export const UpdateProductDocument = gql`
       }
       isPublished
       categories {
+        id
+        name
+      }
+      tags {
         id
         name
       }
@@ -1672,6 +1681,10 @@ export const GetProductByIdDocument = gql`
       isPublished
       deletedAt
       categories {
+        id
+        name
+      }
+      tags {
         id
         name
       }

--- a/client/src/schema/mutations.ts
+++ b/client/src/schema/mutations.ts
@@ -84,6 +84,10 @@ export const PUT_PRODUCT = gql`
         id
         name
       }
+      tags {
+        id
+        name
+      }
     }
   }
 `;

--- a/client/src/schema/queries.ts
+++ b/client/src/schema/queries.ts
@@ -41,6 +41,10 @@ export const GET_PRODUCT_BY_ID = gql`
         id
         name
       }
+      tags {
+        id
+        name
+      }
       brand {
         id
         name


### PR DESCRIPTION
# Add tag management functionality to products

## Description
This PR implements tag management for products, allowing users to add and remove tags during product creation and updates.

## Changes
- Add tag management in product creation form
- Add tag management in product update form
- Visual distinction between categories (grey) and tags (blue)
- Update resolver for tag handling
- Update GraphQL types